### PR TITLE
Smooth out real-time interactivity

### DIFF
--- a/main.h
+++ b/main.h
@@ -19,6 +19,7 @@ extern "C" {
     void setNonblocking();
     void writeVersion();
     void printHelp();
+    void flushArrows();
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
These changes make changing voltage with the arrow keys feel much
smoother, and more importantly less likely to overrun the intended
setpoint. They have the added bonus of making the voltage/current
readouts respond more quickly to the PSU's actual state.

Closes #6 