### PR TITLE
Detect and correct for 1685B current quirk

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,7 @@ double maxVoltage = 0;
 double maxCurrent = 0;
 double currVoltage = 0;
 double currCurrent = 0;
+double currentDivider = 10;
 
 int main(int argc, char** argv) {
 

--- a/serial.cpp
+++ b/serial.cpp
@@ -69,7 +69,7 @@ void setCurrent(int fd, double current) {
         return;
     }
 
-    current *= 10;
+    current *= currentDivider;
 
     sprintf(param, "%03d", (int) current);
 
@@ -241,7 +241,7 @@ void getSettings(int fd) {
     double current = std::stod(data.substr(3, 3), NULL);
 
     voltage /= 10;
-    current /= 10;
+    current /= currentDivider;
 
     currVoltage = voltage;
     currCurrent = current;
@@ -294,6 +294,9 @@ void getCurrent(int fd) {
     bool output = getOutputStatus(fd);
 
     voltage /= 100;
+
+    // Empirically, the 1685B still reports its operating current in the same
+    // format, so we do *not* use currentDivider here
     current /= 100;
 
     move((LINES / 2) - 1, (COLS / 2) - 23);
@@ -399,7 +402,15 @@ void getDeviceCapabilities(int fd) {
     double current = std::stod(data.substr(3, 3), NULL);
 
     voltage /= 10;
-    current /= 10;
+
+    if (voltage >= 60.0) {
+        // the 1685B has one more digit of current precision everywhere
+        currentDivider = 100;
+    } else {
+        currentDivider = 10;
+    }
+
+    current /= currentDivider;
 
     maxCurrent = current;
     maxVoltage = voltage;

--- a/serial.h
+++ b/serial.h
@@ -20,6 +20,7 @@ extern "C" {
     extern bool outputOn;
     extern double currVoltage;
     extern double currCurrent;
+    extern double currentDivider;
 
     bool getSerialPort(char* portAddr);
     int set_interface_attribs(int fd, speed_t speed, int parity);


### PR DESCRIPTION
The 1685B has one more digit of precision in its current values (per
page 11 of the programming manual). This means that the previous code
incorrectly displayed and set current values for that particular
variant.

This changeset detects the presence of a 1685B by examining the power
supply's maximum reported voltage. Though this is a little hacky, it
appears to be the only way to differentiate between the different models
in the 168xB line. If a 1685B is detected, a different current divider
is used.

It's worth noting that the GETD command (used to query the measured
current/voltage levels on the output) appears not to vary between
different PSUs in the line. However, I don't have an 1687B or 1688B with
which to test (yet) -- I'm just operating under the assumption that the
code as-written was working properly for them.

Closes #9 