### PR TITLE
Fix rounding errors in current/voltage commands

### DIFF
--- a/serial.cpp
+++ b/serial.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <ncurses.h>
 #include <errno.h>
+#include <math.h>
 #include <termios.h>
 #include <unistd.h>
 #include <stdio.h>
@@ -48,7 +49,7 @@ void setVoltage(int fd, double voltage) {
 
     voltage *= 10;
 
-    sprintf(param, "%03d", (int) voltage);
+    sprintf(param, "%03d", (int) round(voltage));
 
     cmd.append(param);
     cmd.append("\r");
@@ -71,7 +72,7 @@ void setCurrent(int fd, double current) {
 
     current *= currentDivider;
 
-    sprintf(param, "%03d", (int) current);
+    sprintf(param, "%03d", (int) round(current));
 
     cmd.append(param);
     cmd.append("\r");


### PR DESCRIPTION
Previously, the floating-point current/voltage was simply truncated to
an integer. In certain places, this could cause issues -- most
especially when the voltage was incremented by 0.1 but encountered
rounding errors. This might mean, for instance, that 12.2 + 0.1 became
12.29999, which (when truncated) is still 12.2.

By rounding before the integer conversion, we can sidestep this issue.