### PR TITLE
Fix crash on invalid status response

### DIFF
--- a/serial.cpp
+++ b/serial.cpp
@@ -275,7 +275,7 @@ void getCurrent(int fd) {
 
     std::string data = readData(fd);
 
-    if (data.length() == 0) {
+    if (data.length() == 0 || data.length() < 9) {
         return;
     }
 


### PR DESCRIPTION
I'm working with a 1688B and just caught it returning an unexpected response to `GETD`: voltage and current, but no mode field. This causes an abort due to the exception raised by `string::substr()` when trying to retrieve this field.

This seems to be an intermittent condition so I figured the easiest solution was just to validate the data's length as containing all three fields.