### PR TITLE
Close additional memory leaks by removing dynamic allocation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -37,7 +37,7 @@ double currentDivider = 10;
 int main(int argc, char** argv) {
 
     int ch;
-    char* portAddr = (char*) malloc(255 * sizeof (char));
+    char portAddr[255];
     double userFloatInput = 0;
 
     //start curses
@@ -180,7 +180,6 @@ int main(int argc, char** argv) {
     close(fd);
     //exit curses
     endwin();
-    free(portAddr);
 
     return 0;
 }

--- a/serial.cpp
+++ b/serial.cpp
@@ -40,7 +40,7 @@ void setOutput(int fd, bool on) {
  */
 void setVoltage(int fd, double voltage) {
     std::string cmd = "VOLT";
-    char* param = (char*) malloc(4 * sizeof (char));
+    char param[4];
 
     //do nothing for invalid voltage setting
     if (voltage > maxVoltage || voltage < 0) {
@@ -53,7 +53,6 @@ void setVoltage(int fd, double voltage) {
 
     cmd.append(param);
     cmd.append("\r");
-    free(param);
 
     sendData(fd, cmd.c_str());
     readData(fd);
@@ -64,7 +63,7 @@ void setVoltage(int fd, double voltage) {
  */
 void setCurrent(int fd, double current) {
     std::string cmd = "CURR";
-    char* param = (char*) malloc(4 * sizeof (char));
+    char param[4];
 
     //do nothing for invalid current setting
     if (current > maxCurrent || current < 0) {
@@ -77,7 +76,6 @@ void setCurrent(int fd, double current) {
 
     cmd.append(param);
     cmd.append("\r");
-    free(param);
 
     sendData(fd, cmd.c_str());
     readData(fd);


### PR DESCRIPTION
a5e8ca9c1e50bab620936bcd77009079b433930f doesn't completely fix the memory leaks due to early returns on error detection. There's no need for these buffers to be dynamically allocated anyway (as they never survive their stack frame) so I've just moved them onto the stack.